### PR TITLE
Remove deprecated option `Set Automatic Coercions Import`.

### DIFF
--- a/interfaces/canonical_names.v
+++ b/interfaces/canonical_names.v
@@ -1,6 +1,5 @@
 Global Generalizable All Variables.
 Global Set Automatic Introduction.
-Global Set Automatic Coercions Import.
 
 Require Import MathClasses.theory.Streams.
 Require Export Coq.Classes.Morphisms Coq.Setoids.Setoid Coq.Program.Program Coq.Unicode.Utf8 Coq.Unicode.Utf8_core MathClasses.misc.stdlib_hints.

--- a/varieties/abgroup.v
+++ b/varieties/abgroup.v
@@ -2,7 +2,7 @@
 Require
   MathClasses.categories.varieties MathClasses.categories.product MathClasses.theory.forget_algebra MathClasses.theory.forget_variety MathClasses.theory.groups.
 Require Import
-  MathClasses.interfaces.abstract_algebra MathClasses.interfaces.universal_algebra MathClasses.theory.ua_homomorphisms MathClasses.misc.workaround_tactics.
+  MathClasses.interfaces.abstract_algebra MathClasses.interfaces.universal_algebra MathClasses.theory.ua_homomorphisms MathClasses.misc.workaround_tactics categories.categories.
 
 Inductive op := mult | inv | one.
 

--- a/varieties/groups.v
+++ b/varieties/groups.v
@@ -2,7 +2,7 @@
 Require
   MathClasses.categories.varieties MathClasses.categories.product MathClasses.theory.forget_algebra MathClasses.theory.forget_variety MathClasses.theory.groups.
 Require Import
-  MathClasses.interfaces.abstract_algebra MathClasses.interfaces.universal_algebra MathClasses.theory.ua_homomorphisms MathClasses.misc.workaround_tactics.
+  MathClasses.interfaces.abstract_algebra MathClasses.interfaces.universal_algebra MathClasses.theory.ua_homomorphisms MathClasses.misc.workaround_tactics categories.categories.
 
 Inductive op := mult | inv | one.
 

--- a/varieties/semigroups.v
+++ b/varieties/semigroups.v
@@ -2,7 +2,7 @@
 Require
   MathClasses.categories.varieties MathClasses.categories.product MathClasses.theory.forget_algebra MathClasses.theory.forget_variety.
 Require Import
-  MathClasses.interfaces.abstract_algebra MathClasses.interfaces.universal_algebra MathClasses.theory.ua_homomorphisms MathClasses.misc.workaround_tactics.
+  MathClasses.interfaces.abstract_algebra MathClasses.interfaces.universal_algebra MathClasses.theory.ua_homomorphisms MathClasses.misc.workaround_tactics categories.categories.
 
 Inductive op := mult.
 


### PR DESCRIPTION
Ok, with the right infrastructure (I implemented a warning each time a non-imported coercion is used), the patch was easy.