### PR TITLE
Fix Travis (coq-released is already a remote repository).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ install:
   - sudo apt-get update && sudo apt-get install -y opam
   - opam init -y && eval $(opam config env) && opam config var root
   - travis_wait opam install -y coq
-  - opam repo add coq-released http://coq.inria.fr/opam/released
+  - opam repo add coq-released http://coq.inria.fr/opam/released || true
   - opam install -y coq-bignums
 script: ./configure.sh && make


### PR DESCRIPTION
It seems that recent changes to the `.travis.yml` file have made it possible for Travis builds to fail unpredictably, see https://travis-ci.org/coq-community/math-classes/builds/406368191.

This PR fixes this problem.

However, I believe it will reveal that math-classes is currently broken (since f7c6cca23ecf5cb77563a6fc44dc8320dc1c4f57). We'll see...