### PR TITLE
Make trivial instances explicit

### DIFF
--- a/implementations/dyadics.v
+++ b/implementations/dyadics.v
@@ -423,7 +423,7 @@ Section embed_rationals.
   Notation DtoQ_slow' := (DtoQ_slow ZtoQ).
   Notation StdQtoQ := (rationals_to_rationals StdQ Q).
 
-  Instance: Params (@DtoQ_slow) 6.
+  Instance: Params (@DtoQ_slow) 6 := {}.
   Lemma DtoQ_slow_correct : DtoQ_slow' = StdQtoQ ∘ DtoStdQ.
   Proof.
     intros x y E. unfold compose. rewrite <- E. clear y E.

--- a/interfaces/additional_operations.v
+++ b/interfaces/additional_operations.v
@@ -6,7 +6,7 @@ Infix "^" := pow : mc_scope.
 Notation "(^)" := pow (only parsing) : mc_scope.
 Notation "( x ^)" := (pow x) (only parsing) : mc_scope.
 Notation "(^ n )" := (λ x, x ^ n) (only parsing) : mc_scope.
-Instance: Params (@pow) 3.
+Instance: Params (@pow) 3 := {}.
 
 (* If we make [nat_pow_proper] a subclass, Coq is unable to find it.
 However, if we make a global instance in theory.nat_pow, it works? *)
@@ -28,7 +28,7 @@ Infix "≪" := shiftl (at level 33, left associativity) : mc_scope.
 Notation "(≪)" := shiftl (only parsing) : mc_scope.
 Notation "( x ≪)" := (shiftl x) (only parsing) : mc_scope.
 Notation "(≪ n )" := (λ x, x ≪ n) (only parsing) : mc_scope.
-Instance: Params (@shiftl) 3.
+Instance: Params (@shiftl) 3 := {}.
 
 Class ShiftLSpec A B (sl : ShiftL A B) `{Equiv A} `{Equiv B} `{One A} `{Plus A} `{Mult A} `{Zero B} `{One B} `{Plus B} := {
   shiftl_proper : Proper ((=) ==> (=) ==> (=)) (≪) ;
@@ -64,7 +64,7 @@ Qed.
 Class ShiftR A B := shiftr: A → B → A.
 Infix "≫" := shiftr (at level 33, left associativity) : mc_scope.
 Notation "(≫)" := shiftr (only parsing) : mc_scope.
-Instance: Params (@shiftr) 3.
+Instance: Params (@shiftr) 3 := {}.
 
 Class ShiftRSpec A B (sl : ShiftR A B) `{Equiv A} `{Equiv B} `{One A} `{Plus A} `{Mult A} `{Zero B} `{One B} `{Plus B} := {
   shiftr_proper : Proper ((=) ==> (=) ==> (=)) (≫) ;
@@ -82,8 +82,8 @@ Infix "`mod`" := mod_euclid (at level 40) : mc_scope.
 Notation "(`mod` )" := mod_euclid (only parsing) : mc_scope.
 Notation "( x `mod`)" := (mod_euclid x) (only parsing) : mc_scope.
 Notation "(`mod` y )" := (λ x, x `mod` y) (only parsing) : mc_scope.
-Instance: Params (@div_euclid) 2.
-Instance: Params (@mod_euclid) 2.
+Instance: Params (@div_euclid) 2 := {}.
+Instance: Params (@mod_euclid) 2 := {}.
 
 Class EuclidSpec A (d : DivEuclid A) (m : ModEuclid A) `{Equiv A} `{Le A} `{Lt A} `{Zero A} `{Plus A} `{Mult A} := {
   div_proper : Proper ((=) ==> (=) ==> (=)) (`div`) ;
@@ -99,7 +99,7 @@ Infix "∸" := cut_minus (at level 50, left associativity) : mc_scope.
 Notation "(∸)" := cut_minus (only parsing) : mc_scope.
 Notation "( x ∸)" := (cut_minus x) (only parsing) : mc_scope.
 Notation "(∸ y )" := (λ x, x ∸ y) (only parsing) : mc_scope.
-Instance: Params (@cut_minus) 2.
+Instance: Params (@cut_minus) 2 := {}.
 
 Class CutMinusSpec A (cm : CutMinus A) `{Equiv A} `{Zero A} `{Plus A} `{Le A} := {
   cut_minus_le : ∀ x y, y ≤ x → x ∸ y + y = x ;

--- a/interfaces/canonical_names.v
+++ b/interfaces/canonical_names.v
@@ -31,7 +31,7 @@ Hint Extern 2 (?x = ?y) => auto_symm.
 Hint Extern 2 (?x = ?y) => auto_trans.
 
 (* Coq sometimes uses an incorrect DefaultRelation, so we override it. *)
-Instance equiv_default_relation `{Equiv A} : DefaultRelation (=) | 3.
+Instance equiv_default_relation `{Equiv A} : DefaultRelation (=) | 3 := {}.
 
 (*
 Because Coq does not support setoid rewriting in Type'd relations
@@ -96,7 +96,7 @@ Hint Extern 10 (Apart (sig _)) => apply @sig_apart : typeclass_instances.
 Class Cast A B := cast: A → B.
 Arguments cast _ _ {Cast} _.
 Notation "' x" := (cast _ _ x) (at level 20) : mc_scope.
-Instance: Params (@cast) 3.
+Instance: Params (@cast) 3 := {}.
 Typeclasses Transparent Cast.
 
 (* Other canonically named relations/operations/constants: *)
@@ -143,20 +143,20 @@ Class RalgebraAction A B := ralgebra_action: A → B → B.
 Arguments cat_id {O arrows CatId x} : rename.
 Arguments comp {O arrow CatComp} _ _ _ _ _ : rename.
 
-Instance: Params (@mult) 2.
-Instance: Params (@plus) 2.
-Instance: Params (@negate) 2.
-Instance: Params (@equiv) 2.
-Instance: Params (@apart) 2.
-Instance: Params (@le) 2.
-Instance: Params (@lt) 2.
-Instance: Params (@recip) 4.
-Instance: Params (@dec_recip) 2.
-Instance: Params (@meet) 2.
-Instance: Params (@join) 2.
-Instance: Params (@contains) 3.
-Instance: Params (@singleton) 3.
-Instance: Params (@difference) 2.
+Instance: Params (@mult) 2 := {}.
+Instance: Params (@plus) 2 := {}.
+Instance: Params (@negate) 2 := {}.
+Instance: Params (@equiv) 2 := {}.
+Instance: Params (@apart) 2 := {}.
+Instance: Params (@le) 2 := {}.
+Instance: Params (@lt) 2 := {}.
+Instance: Params (@recip) 4 := {}.
+Instance: Params (@dec_recip) 2 := {}.
+Instance: Params (@meet) 2 := {}.
+Instance: Params (@join) 2 := {}.
+Instance: Params (@contains) 3 := {}.
+Instance: Params (@singleton) 3 := {}.
+Instance: Params (@difference) 2 := {}.
 
 Instance plus_is_sg_op `{f : Plus A} : SgOp A := f.
 Instance mult_is_sg_op `{f : Mult A} : SgOp A := f.
@@ -296,8 +296,8 @@ Hint Extern 4 (?x < ?z) => auto_trans.
 
 Class Abs A `{Equiv A} `{Le A} `{Zero A} `{Negate A} := abs_sig: ∀ (x : A), { y : A | (0 ≤ x → y = x) ∧ (x ≤ 0 → y = -x)}.
 Definition abs `{Abs A} := λ x : A, ` (abs_sig x).
-Instance: Params (@abs_sig) 6.
-Instance: Params (@abs) 6.
+Instance: Params (@abs_sig) 6 := {}.
+Instance: Params (@abs) 6 := {}.
 
 (* Common properties: *)
 Class Inverse `(A → B) : Type := inverse: B → A.

--- a/interfaces/integers.v
+++ b/interfaces/integers.v
@@ -29,7 +29,7 @@ Section initial_maps.
   Qed.
 End initial_maps.
 
-Instance: Params (@integers_to_ring) 8.
+Instance: Params (@integers_to_ring) 8 := {}.
 
 Class Integers A {e plus mult zero one negate} `{U : IntegersToRing A} :=
   { integers_ring:> @Ring A e plus mult zero one negate
@@ -55,6 +55,6 @@ Section specializable.
     end.
 End specializable.
 
-Instance: Params (@int_abs) 10.
-Instance: Params (@int_abs_sig) 10.
-Instance: Params (@int_to_nat) 11.
+Instance: Params (@int_abs) 10 := {}.
+Instance: Params (@int_abs_sig) 10 := {}.
+Instance: Params (@int_to_nat) 11 := {}.

--- a/interfaces/naturals.v
+++ b/interfaces/naturals.v
@@ -36,7 +36,7 @@ Section initial_maps.
   Qed.
 End initial_maps.
 
-Instance: Params (@naturals_to_semiring) 7.
+Instance: Params (@naturals_to_semiring) 7 := {}.
 
 Class Naturals A {e plus mult zero one} `{U: NaturalsToSemiRing A} :=
   { naturals_ring:> @SemiRing A e plus mult zero one
@@ -51,5 +51,5 @@ Definition nat_distance `{nd : NatDistance N} (x y : N) :=
   | inl (n↾_) => n
   | inr (n↾_) => n
   end.
-Instance: Params (@nat_distance_sig) 4.
-Instance: Params (@nat_distance) 4.
+Instance: Params (@nat_distance_sig) 4 := {}.
+Instance: Params (@nat_distance) 4 := {}.

--- a/interfaces/vectorspace.v
+++ b/interfaces/vectorspace.v
@@ -3,7 +3,7 @@ Require Import
 
 (** Scalar multiplication function class *)
 Class ScalarMult K V := scalar_mult: K → V → V.
-Instance: Params (@scalar_mult) 3.
+Instance: Params (@scalar_mult) 3 := {}.
 
 Infix "·" := scalar_mult (at level 50) : mc_scope.
 Notation "(·)" := scalar_mult (only parsing) : mc_scope.
@@ -12,7 +12,7 @@ Notation "(· x )" := (λ y, y · x) (only parsing) : mc_scope.
 
 (** The inproduct function class *)
 Class Inproduct K V := inprod : V → V → K.
-Instance: Params (@inprod) 3.
+Instance: Params (@inprod) 3 := {}.
 
 Notation "(⟨⟩)" := (inprod) (only parsing) : mc_scope.
 Notation "⟨ u , v ⟩" := (inprod u v) (at level 51) : mc_scope.
@@ -22,7 +22,7 @@ Notation "x ⊥ y" := (⟨x,y⟩ = 0) (at level 70) : mc_scope.
 
 (** The norm function class *)
 Class Norm K V := norm : V → K.
-Instance: Params (@norm) 2.
+Instance: Params (@norm) 2 := {}.
 
 Notation "∥ L ∥" := (norm L) (at level 50) : mc_scope.
 Notation "∥·∥" := norm (only parsing) : mc_scope.


### PR DESCRIPTION
This is in preparation for https://github.com/coq/coq/pull/9274.

Should be backward-compatible, but that remains to be tested.