### PR TITLE
Meta file, CI, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ coqdoc
 *.o
 *.native
 *.aux
+result

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,49 @@
-sudo: required
-language: c
-cache:
-  apt: true
-  directories:
-    - $HOME/.opam
-install:
-  # https://opam.ocaml.org/doc/Install.html#Ubuntu
-  - sudo add-apt-repository --yes ppa:avsm/ppa
-  - sudo apt-get update && sudo apt-get install -y opam
-  - opam init -y && eval $(opam config env) && opam config var root
-  - travis_wait opam install -y coq
-  - opam repo add coq-released http://coq.inria.fr/opam/released || true
-  - opam install -y coq-bignums
-script: ./configure.sh && make
+language: nix
+
+script:
+- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+
+matrix:
+  include:
+
+  # Test supported versions of Coq
+  - env: COQ=https://github.com/coq/coq/tarball/master
+  - env: COQ=8.9
+  - env: COQ=8.8
+  - env: COQ=8.7
+  - env: COQ=8.6
+
+  # Test opam package
+  - language: minimal
+    sudo: required
+    services: docker
+    env:
+    - COQ_IMAGE=coqorg/coq:dev
+    - CONTRIB_NAME=math-classes
+    - NJOBS=2
+    install: |
+      # Prepare the COQ container
+      docker pull ${COQ_IMAGE}
+      docker run -d -i --init --name=COQ -v ${TRAVIS_BUILD_DIR}:/home/coq/${CONTRIB_NAME} -w /home/coq/${CONTRIB_NAME} ${COQ_IMAGE}
+      docker exec COQ /bin/bash --login -c "
+        # This bash script is double-quoted to interpolate Travis CI env vars:
+        echo \"Build triggered by ${TRAVIS_EVENT_TYPE}\"
+        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+        set -ex  # -e = exit on failure; -x = trace for debug
+        opam update -y
+        opam install -y -j ${NJOBS} --deps-only .
+        opam config list
+        opam repo list
+        opam list
+        "
+    script:
+    - echo -e "${ANSI_YELLOW}Building ${CONTRIB_NAME}...${ANSI_RESET}" && echo -en 'travis_fold:start:script\\r'
+    - |
+      docker exec COQ /bin/bash --login -c "
+        export PS4='+ \e[33;1m(\$0 @ line \$LINENO) \$\e[0m '
+        set -ex
+        sudo chown -R coq:coq /home/coq/${CONTRIB_NAME}
+        opam install -y -j ${NJOBS} .
+        "
+    - docker stop COQ  # optional
+    - echo -en 'travis_fold:end:script\\r'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: nix
 
 script:
-- nix-build --argstr coq-version-or-url "$COQ" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
+- nix-build --argstr coq-version-or-url "$COQ" --argstr bignums-url "$BIGNUMS" --extra-substituters https://coq.cachix.org --trusted-public-keys "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= coq.cachix.org-1:Jgt0DwGAUo+wpxCM52k2V+E0hLoOzFPzvg94F65agtI="
 
 matrix:
   include:
 
   # Test supported versions of Coq
-  - env: COQ=https://github.com/coq/coq/tarball/master
+  - env:
+      COQ=https://github.com/coq/coq/tarball/master
+      BIGNUMS=https://github.com/coq/bignums/tarball/master
   - env: COQ=8.9
   - env: COQ=8.8
   - env: COQ=8.7

--- a/README.md
+++ b/README.md
@@ -1,8 +1,71 @@
-## Compilation
-This code has been tested with 8.6 through 8.8.1. The other branches are deprecated.
-The code depends on [BigNums](https://github.com/coq/bignums) which can be installed using opam.
+# Math Classes
+
+[![Travis][travis-shield]][travis-link]
+[![Contributing][contributing-shield]][contributing-link]
+[![Code of Conduct][conduct-shield]][conduct-link]
+[![Gitter][gitter-shield]][gitter-link]
+[![DOI][doi-shield]][doi-link]
+
+[doi-shield]: https://zenodo.org/badge/DOI/10.1017/S0960129511000119.svg
+[doi-link]: https://doi.org/10.1017/S0960129511000119
+
+[travis-shield]: https://travis-ci.com/coq-community/math-classes.svg?branch=master
+[travis-link]: https://travis-ci.com/coq-community/math-classes/builds
+
+[contributing-shield]: https://img.shields.io/badge/contributions-welcome-%23f7931e.svg
+[contributing-link]: https://github.com/coq-community/manifesto/blob/master/CONTRIBUTING.md
+
+[conduct-shield]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-%23f15a24.svg
+[conduct-link]: https://github.com/coq-community/manifesto/blob/master/CODE_OF_CONDUCT.md
+
+[gitter-shield]: https://img.shields.io/badge/chat-on%20gitter-%23c1272d.svg
+[gitter-link]: https://gitter.im/coq-community/Lobby
+
+A library of abstract interfaces for mathematical structures in Coq.
+
+
+More details about the project can be found in the paper
+[Type Classes for Mathematics in Type Theory](https://arxiv.org/abs/1102.1323).
+
+## Meta
+
+- Author(s):
+  - Eelis van der Weegen (initial)
+  - Bas Spitters (initial)
+  - Robbert Krebbers (initial)
+- Coq-community maintainer(s):
+  - Bas Spitters ([**@spitters**](https://github.com/spitters))
+- License: [Public Domain](LICENSE)
+- Compatible Coq versions: Coq 8.6 or later (use releases for other Coq versions)
+- Additional dependencies:
+  - [BigNums](https://github.com/coq/bignums)
+
+
+## Building and installation instructions
+
+The easiest way to install the latest released version is via
+[OPAM](https://opam.ocaml.org/doc/Install.html):
+
+```shell
+opam repo add coq-released https://coq.inria.fr/opam/released
+opam install coq-math-classes
+```
+
+To instead build and install manually, do:
+
+``` shell
+git clone https://github.com/coq-community/math-classes
+cd math-classes
+./configure.sh
+make   # or make -j <number-of-cores-on-your-machine>
+make install
+```
+
+After installation, the included modules are available under
+the `MathClasses` namespace.
 
 ## Directory structure
+
 ### categories/
 Proofs that certain structures form categories.
 
@@ -34,3 +97,4 @@ The reason we treat categories and varieties differently from other structures
 are not concrete data structures and algorithms but are themselves abstract structures.
 
 To be able to distinguish the various arrows, we recommend using a variable width font.
+

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ pkgs ? (import <nixpkgs> {}), coq-version-or-url, shell ? false }:
+{ pkgs ? (import <nixpkgs> {}), coq-version-or-url, bignums-url ? "", shell ? false }:
 
 let
   coq-version-parts = builtins.match "([0-9]+).([0-9]+)" coq-version-or-url;
@@ -7,6 +7,11 @@ let
       pkgs.mkCoqPackages (import (fetchTarball coq-version-or-url) {})
     else
       pkgs."coqPackages_${builtins.concatStringsSep "_" coq-version-parts}";
+  bignums =
+    if bignums-url == "" then coqPackages.bignums else
+      coqPackages.bignums.overrideAttrs (o: {
+        src = fetchTarball https://github.com/coq/bignums/archive/master.tar.gz;
+      });
 in
 
 with coqPackages;

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{ pkgs ? (import <nixpkgs> {}), coq-version-or-url, shell ? false }:
+
+let
+  coq-version-parts = builtins.match "([0-9]+).([0-9]+)" coq-version-or-url;
+  coqPackages =
+    if coq-version-parts == null then
+      pkgs.mkCoqPackages (import (fetchTarball coq-version-or-url) {})
+    else
+      pkgs."coqPackages_${builtins.concatStringsSep "_" coq-version-parts}";
+in
+
+with coqPackages;
+
+pkgs.stdenv.mkDerivation {
+
+  name = "math-classes";
+
+  propagatedBuildInputs = [
+    coq
+    bignums
+  ];
+
+  src = if shell then null else ./.;
+
+  installFlags = "COQLIB=$(out)/lib/coq/${coq.coq-version}/";
+}

--- a/meta.yml
+++ b/meta.yml
@@ -1,0 +1,86 @@
+---
+fullname: Math Classes
+shortname: math-classes
+
+description: |
+  A library of abstract interfaces for mathematical structures in Coq.
+
+paper:
+  doi: 10.1017/S0960129511000119
+  url: https://arxiv.org/abs/1102.1323
+  title: Type Classes for Mathematics in Type Theory
+
+authors:
+- name: Eelis van der Weegen
+  initial: true
+- name: Bas Spitters
+  initial: true
+- name: Robbert Krebbers
+  initial: true
+
+maintainers:
+- name: Bas Spitters
+  nickname: spitters
+
+opam-file-maintainer: b.a.w.spitters@gmail.com
+
+license:
+  fullname: Public Domain
+  shortname: Public Domain
+
+supported_coq_versions:
+  text: Coq 8.6 or later (use releases for other Coq versions)
+  opam: '{(>= "8.6" & < "8.10~") | (= "dev")}'
+
+tested_coq_versions:
+- version_or_url: https://github.com/coq/coq/tarball/master
+- version_or_url: 8.9
+- version_or_url: 8.8
+- version_or_url: 8.7
+- version_or_url: 8.6
+
+tested_coq_opam_version: dev
+
+dependencies:
+- opam:
+    name: coq-bignums
+  nix: bignums
+  description: "[BigNums](https://github.com/coq/bignums)"
+
+namespace: MathClasses
+
+documentation: |
+  ## Directory structure
+
+  ### categories/
+  Proofs that certain structures form categories.
+
+  ### functors/
+
+  ### interfaces/
+  Definitions of abstract interfaces/structures.
+
+  ### implementations/
+  Definitions of concrete data structures and algorithms, and proofs that they are instances of certain structures (i.e. implement certain interfaces).
+
+  ### misc/
+  Miscellaneous things.
+
+  ### orders/
+  Theory about orders on different structures.
+
+  ### quote/
+  Prototype implementation of type class based quoting. To be integrated.
+
+  ### theory/
+  Proofs of properties of structures.
+
+  ### varieties/
+  Proofs that certain structures are varieties, and translation to/from type classes dedicated to these structures (defined in interfaces/).
+
+  The reason we treat categories and varieties differently from other structures
+  (like groups and rings) is that they are like meta-interfaces whose implementations
+  are not concrete data structures and algorithms but are themselves abstract structures.
+
+  To be able to distinguish the various arrows, we recommend using a variable width font.
+---

--- a/opam
+++ b/opam
@@ -1,24 +1,27 @@
 opam-version: "1.2"
 maintainer: "b.a.w.spitters@gmail.com"
-homepage: "https://github.com/math-classes/"
-doc: "https://github.com/math-classes/"
-name: "coq-math-classes"
-version: "dev"
-authors: [
-  "Eelis van der Weegen"
-  "Bas Spitters"
-  "Robbert Krebbers"
-]
+
+homepage: "https://github.com/coq-community/math-classes"
+dev-repo: "https://github.com/coq-community/math-classes.git"
+bug-reports: "https://github.com/coq-community/math-classes/issues"
 license: "Public Domain"
+
 build: [
   [ "./configure.sh" ]
   [ make "-j%{jobs}%" ]
 ]
-install: [
-  [ make "install" ]
-]
+install: [make "install"]
 remove: ["rm" "-R" "%{lib}%/coq/user-contrib/MathClasses"]
 depends: [
-  "coq" {>= "8.6"}
-  "coq-bignums" {>= "8.6"}
+  "coq" {(>= "8.6" & < "8.10~") | (= "dev")}
+  "coq-bignums" 
+]
+
+tags: [
+  "logpath:MathClasses"
+]
+authors: [
+  "Eelis van der Weegen"
+  "Bas Spitters"
+  "Robbert Krebbers"
 ]


### PR DESCRIPTION
I didn't know how to fix the preexisting CI configuration. Instead, I just applied the coq-community templates that are already in use in a number of other coq-community projects.

These templates (available in https://github.com/coq-community/manifesto/tree/master/templates) are used to generate the `.travis.yml`, `README.md`, `default.nix`, and `opam` files, taking the information they need from the `meta.yml` file.

Compared to what these templates generate, I had to do two small and one larger fix:
- use `travis-ci.org` instead of `travis-ci.com` (I will reach Travis to migrate the repository to `travis-ci.com` which will allow us to benefit from the "Checks tab");
- add the `./configure.sh` build step (soon enough this will go away when all Coq packages can be built with Dune);
- fetch bignums from the right place when building with Coq master (this should be handled in full generality: I will track this in coq-community/manifesto#37).

Something else that is not done yet but should be (and will be tracked as well in coq-community/manifesto#37) is a way to cache the build output of Bignums (when neither Coq nor Bignums have changed, which is not so often however).