### PR TITLE
Use coq-on-cachix repo to never rebuild the Coq package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
 
   # Test supported versions of Coq
   - env:
-      COQ=https://github.com/coq/coq/tarball/master
+      COQ=https://github.com/coq/coq-on-cachix/tarball/master
       BIGNUMS=https://github.com/coq/bignums/tarball/master
   - env: COQ=8.9
   - env: COQ=8.8

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ More details about the project can be found in the paper
   - Eelis van der Weegen (initial)
   - Bas Spitters (initial)
   - Robbert Krebbers (initial)
-- Coq-community maintainer(s):
+- Maintainer(s):
   - Bas Spitters ([**@spitters**](https://github.com/spitters))
 - License: [Public Domain](LICENSE)
 - Compatible Coq versions: Coq 8.6 or later (use releases for other Coq versions)

--- a/meta.yml
+++ b/meta.yml
@@ -1,6 +1,7 @@
 ---
 fullname: Math Classes
 shortname: math-classes
+organization: coq-community
 
 description: |
   A library of abstract interfaces for mathematical structures in Coq.
@@ -33,7 +34,7 @@ supported_coq_versions:
   opam: '{(>= "8.6" & < "8.10~") | (= "dev")}'
 
 tested_coq_versions:
-- version_or_url: https://github.com/coq/coq/tarball/master
+- version_or_url: https://github.com/coq/coq-on-cachix/tarball/master
 - version_or_url: 8.9
 - version_or_url: 8.8
 - version_or_url: 8.7


### PR DESCRIPTION
The coq-on-cachix repo lags a bit behind the main Coq repo but guarantees that it has already been built and uploaded to Cachix.

See also https://github.com/coq/coq/wiki/Nix.

This commit also updates a few other things following recent changes in the coq-community templates.