### PR TITLE
ne_list: move the coercion into a dedicated module

### DIFF
--- a/implementations/ne_list.v
+++ b/implementations/ne_list.v
@@ -37,7 +37,7 @@ Section contents.
     | cons x xs => x :: to_list xs
     end.
 
-  Global Coercion to_list: L >-> list.
+  Local Coercion to_list: L >-> list.
 
   Fixpoint from_list (x: T) (xs: list T): L :=
     match xs with
@@ -113,6 +113,10 @@ Section contents.
    reflexivity.
   Qed.
 End contents.
+
+Module Export coercions.
+  Coercion to_list: L >-> list.
+End coercions.
 
 Arguments L : clear implicits.
 


### PR DESCRIPTION
Similar to the `notations` module, this enables to import from the `ne_list` module the coercions only. This will prove useful when https://github.com/coq/coq/pull/8094 is merged.