### PR TITLE
PR coq/coq#10762 overlay

### DIFF
--- a/interfaces/abstract_algebra.v
+++ b/interfaces/abstract_algebra.v
@@ -47,7 +47,7 @@ Section setoid_morphisms.
 End setoid_morphisms.
 
 Arguments sm_proper {A B Ae Be f Setoid_Morphism} _ _ _.
-Hint Extern 4 (?f _ = ?f _) => eapply (sm_proper (f:=f)).
+Hint Extern 4 (?f _ = ?f _) => unshelve eapply (sm_proper (f:=f)).
 
 Section setoid_binary_morphisms.
   Context {A B C} {Ae: Equiv A} {Aap: Apart A} 


### PR DESCRIPTION
PR coq/coq#10762 overlay

Add an unshelve to eapply, which otherwise will always succeed but leave a shelved Setoid_Morphism constraint.

With the fixed eapply semantics of shelving and marking unresolvable the remaining dependent subgoals, this results in a hint declaration which creates a shelved goal for an independent subgoal Setoid_Morphism (as the argument is declared maximally implicit). The fix is simply to unshelve this goal and let auto solve it.