### PR TITLE
stdlib_rationals: explicitly require and import ZArith

### DIFF
--- a/implementations/stdlib_rationals.v
+++ b/implementations/stdlib_rationals.v
@@ -1,6 +1,7 @@
 Require
   MathClasses.implementations.stdlib_binary_integers Coq.setoid_ring.Field Coq.QArith.Qfield MathClasses.theory.rationals.
 Require Import
+  Coq.ZArith.ZArith
   Coq.setoid_ring.Ring Coq.QArith.QArith_base Coq.QArith.Qabs Coq.QArith.Qpower
   MathClasses.interfaces.abstract_algebra MathClasses.interfaces.rationals
   MathClasses.interfaces.orders MathClasses.interfaces.additional_operations


### PR DESCRIPTION
The “stdlib_rationals” module depends on ZArith.

This patch makes this dependency explicit, instead of relying on some (accidental) export from an other module.

This is an overlay for https://github.com/coq/coq/pull/10983