### PR TITLE
switch to MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,21 @@
-All authors involved in the creation of the contents of this package have agreed to release their respective contributions into the Public Domain except where noted otherwise.
+The MIT License (MIT)
+
+Copyright (c) 2009-present, Math Classes authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ notations.
   - Robbert Krebbers (initial)
 - Coq-community maintainer(s):
   - Bas Spitters ([**@spitters**](https://github.com/spitters))
-- License: [Public Domain](LICENSE)
+- License: [MIT License](LICENSE)
 - Compatible Coq versions: Coq 8.6 or later (use releases for other Coq versions)
 - Additional dependencies:
   - [BigNums](https://github.com/coq/bignums)

--- a/coq-math-classes.opam
+++ b/coq-math-classes.opam
@@ -5,7 +5,7 @@ version: "dev"
 homepage: "https://github.com/coq-community/math-classes"
 dev-repo: "git+https://github.com/coq-community/math-classes.git"
 bug-reports: "https://github.com/coq-community/math-classes/issues"
-license: "Public Domain"
+license: "MIT"
 
 synopsis: "A library of abstract interfaces for mathematical structures in Coq."
 description: """

--- a/meta.yml
+++ b/meta.yml
@@ -44,8 +44,8 @@ maintainers:
 opam-file-maintainer: b.a.w.spitters@gmail.com
 
 license:
-  fullname: Public Domain
-  identifier: Public Domain
+  fullname: MIT License
+  identifier: MIT
 
 supported_coq_versions:
   text: Coq 8.6 or later (use releases for other Coq versions)


### PR DESCRIPTION
Minimal changes to switch license. This is (in my view) a prerequisite for joining the Coq Platform. Fixes #87.