### PR TITLE
Remove the reliance on forward class hints

### DIFF
--- a/interfaces/vectorspace.v
+++ b/interfaces/vectorspace.v
@@ -33,8 +33,8 @@ Class Module (R M : Type)
   {Me Mop Munit Mnegate}
   {sm : ScalarMult R M}
 :=
-  { lm_ring            :>> @Ring R Re Rplus Rmult Rzero Rone Rnegate
-  ; lm_group           :>> @AbGroup M Me Mop Munit Mnegate
+  { lm_ring            :> @Ring R Re Rplus Rmult Rzero Rone Rnegate
+  ; lm_group           :> @AbGroup M Me Mop Munit Mnegate
   ; lm_distr_l         :> LeftHeteroDistribute (·) (&) (&)
   ; lm_distr_r         :> RightHeteroDistribute (·) (+) (&)
   ; lm_assoc           :> HeteroAssociative (·) (·) (·) (.*.)
@@ -51,9 +51,9 @@ Class Seminormed
  `{!Abs R} (n : Norm R M)
 :=
   (* We have a module *)
-  { snm_module      :>> @Module R M Re Rplus Rmult Rzero Rone Rnegate
+  { snm_module      :> @Module R M Re Rplus Rmult Rzero Rone Rnegate
                                   Me Mop Munit Mnegate Smult
-  ; snm_order       :>> @FullPseudoSemiRingOrder R Re Rapart Rplus Rmult Rzero Rone Rle Rlt
+  ; snm_order       :> @FullPseudoSemiRingOrder R Re Rapart Rplus Rmult Rzero Rone Rle Rlt
 
   (* With respect to which our norm preserves the following: *)
   ; snm_scale       :  ∀ a v, ∥a · v∥ = (abs a) * ∥v∥   (* positive homgeneity *)
@@ -70,9 +70,9 @@ Class VectorSpace (K V : Type)
    {Ve Vop Vunit Vnegate}                     (* vector operations *)
    {sm : ScalarMult K V}
  :=
-   { vs_field         :>> @DecField K Ke Kplus Kmult Kzero Kone Knegate Krecip
-   ; vs_abgroup       :>> @AbGroup V Ve Vop Vunit Vnegate
-   ; vs_module        :>> @Module K V Ke Kplus Kmult Kzero Kone Knegate
+   { vs_field         :> @DecField K Ke Kplus Kmult Kzero Kone Knegate Krecip
+   ; vs_abgroup       :> @AbGroup V Ve Vop Vunit Vnegate
+   ; vs_module        :> @Module K V Ke Kplus Kmult Kzero Kone Knegate
                                       Ve Vop Vunit Vnegate sm
    }.
 
@@ -84,9 +84,9 @@ Class InnerProductSpace (K V : Type)
    {Ve Vop Vunit Vnegate}                     (* vector operations *)
    {sm : ScalarMult K V} {inp: Inproduct K V} {Kle: Le K}
  :=
-   { in_vectorspace   :>> @VectorSpace K V Ke Kplus Kmult Kzero Kone Knegate
+   { in_vectorspace   :> @VectorSpace K V Ke Kplus Kmult Kzero Kone Knegate
                                       Krecip Ve Vop Vunit Vnegate sm
-   ; in_srorder       :>> SemiRingOrder Kle
+   ; in_srorder       :> SemiRingOrder Kle
    ; in_comm          :> Commutative inprod
    ; in_linear_l      :  ∀ a u v, ⟨a·u,v⟩ = a*⟨u,v⟩
    ; in_nonneg        :> ∀ v, PropHolds (0 ≤ ⟨v,v⟩) (* TODO Le to strong? *)
@@ -112,7 +112,7 @@ Class SemiNormedSpace (K V : Type)
    {Ve Vop Vunit Vnegate}                     (* vector operations *)
    {sm : ScalarMult K V}
  :=
-   { sn_vectorspace :>> @VectorSpace K V Ke Kplus Kmult Kzero Kone Knegate
+   { sn_vectorspace :> @VectorSpace K V Ke Kplus Kmult Kzero Kone Knegate
                                     Krecip Ve Vop Vunit Vnegate sm
    ; sn_nonneg      :  ∀ v, 0 ≤ ∥v∥                     (* non-negativity *)
    ; sn_scale       :  ∀ a v, ∥a · v∥ = (abs a) * ∥v∥   (* positive homgeneity *)


### PR DESCRIPTION
This feature is undocumented and not tested properly, so likely to be buggy. The file `interfaces/vectorspace.v` seems to be the only one in the whole Coq CI to rely on this feature, since fed14f75b6d114f433ee58d2cfdee61139f6b136, which was supposed to be a *cleanup*. Given that math-classes keeps compiling after doing it, I believe it is safer to simply remove its use altogether.