### PR TITLE
Future proof EuclidSpec

### DIFF
--- a/implementations/ZType_integers.v
+++ b/implementations/ZType_integers.v
@@ -150,7 +150,7 @@ Proof.
       apply (strictly_order_reflecting to_Z). now rewrite spec_modulo.
      apply (order_reflecting to_Z). now rewrite spec_modulo, rings.preserves_0.
    intros x. unfold_equiv. rewrite spec_div, rings.preserves_0. now apply Zdiv_0_r.
-  intros x. unfold_equiv. rewrite spec_modulo, rings.preserves_0. now apply Zmod_0_r.
+  intros x. unfold_equiv. unfold Nat.modulo. rewrite spec_modulo, rings.preserves_0. now apply Zmod_0_r.
 Qed.
 
 Lemma ZType_succ_1_plus x : succ x = 1 + x.

--- a/interfaces/additional_operations.v
+++ b/interfaces/additional_operations.v
@@ -91,7 +91,7 @@ Class EuclidSpec A (d : DivEuclid A) (m : ModEuclid A) `{Equiv A} `{Le A} `{Lt A
   div_mod : ∀ x y, y ≠ 0 → x = y * x `div` y + x `mod` y ;
   mod_rem : ∀ x y, y ≠ 0 → 0 ≤ x `mod` y < y ∨ y < x `mod` y ≤ 0 ;
   div_0 : ∀ x, x `div` 0 = 0 ;
-  mod_0 : ∀ x, x `mod` 0 = 0
+  mod_0 : ∀ x, x `mod` 0 = match (Nat.modulo 1 0) with | 0 => 0 | _ => x end
 }.
 
 Class CutMinus A := cut_minus : A → A → A.


### PR DESCRIPTION
This PR makes EuclidSpec work with https://github.com/coq/coq/pull/14086 in a backwards compatible manner.