### PR TITLE
Fix performance bug

### DIFF
--- a/interfaces/abstract_algebra.v
+++ b/interfaces/abstract_algebra.v
@@ -265,3 +265,8 @@ Section jections.
     { bijective_injective :> Injective
     ; bijective_surjective :> Surjective }.
 End jections.
+
+Instance: Params (@StrongInjective) 4 := {}.
+Instance: Params (@Injective) 4 := {}.
+Instance: Params (@Surjective) 4 := {}.
+Instance: Params (@Bijective) 4 := {}.

--- a/interfaces/universal_algebra.v
+++ b/interfaces/universal_algebra.v
@@ -249,6 +249,7 @@ End for_signature.
 (* Avoid eager application *)
 Remove Hints ua_vars_equiv : typeclass_instances.
 Hint Extern 0 (Equiv (Vars _ _ _)) => eapply @ua_vars_equiv : typeclass_instances.
+Instance: Params (@eval_stmt) 3 := {}.
 
 (* And with that, we define equational theories and varieties: *)
 

--- a/theory/sequences.v
+++ b/theory/sequences.v
@@ -4,6 +4,8 @@ Require Import
   MathClasses.interfaces.abstract_algebra
   MathClasses.interfaces.sequences.
 
+Instance: Params (@extend) 6 := {}.
+
 Section contents.
   Context `{Sequence sq}.
 


### PR DESCRIPTION
The library was crucially missing some `Params` declarations, resulting in simple rewrites that could take seconds to perform.
This is worsened by the upcoming PR coq/coq#13969 which (correctly) infers more sensible default morphism declarations for parts of the goals that are not affected by a rewrite, resulting in even longer proof search. This should be backwards compatible and also a net improvement in performance.