### PR TITLE
make compilation work for coq <= 8.10

### DIFF
--- a/theory/monoid_normalization.v
+++ b/theory/monoid_normalization.v
@@ -73,7 +73,7 @@ Section contents.
     | Comp (Comp x y) z => internal_simplify (Comp x (Comp y z))
     end.
 
-  Solve Obligations with (program_simpl; simpl; try apply reflexivity; lia).
+  Solve Obligations with (program_simpl; simpl; try apply reflexivity; clear internal_simplify; lia).
 
   Next Obligation.
    destruct internal_simplify.


### PR DESCRIPTION
On older coqc versions, lia will go into an infinite loop here
if there is confusing stuff in the context.  So we clean up
the context a little in order to get backwards compatibility.

With this patch, different coq versions can use the same
version of the math-classes library. 
It would for instance make obsolete this suggested patch to the nix-file
https://github.com/NixOS/nixpkgs/pull/129766/commits/fdfbe8691fd75aaba4718fc9add8daa04dde3e5f
