### PR TITLE
Introducing CI for Coq 8.18.

### DIFF
--- a/.github/workflows/docker-action.yml
+++ b/.github/workflows/docker-action.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         image:
           - 'coqorg/coq:dev'
+          - 'coqorg/coq:8.18'
           - 'coqorg/coq:8.17'
           - 'coqorg/coq:8.16'
           - 'coqorg/coq:8.15'

--- a/coq-math-classes.opam
+++ b/coq-math-classes.opam
@@ -30,7 +30,7 @@ build: [
 ]
 install: [make "install"]
 depends: [
-  "coq" {(>= "8.11" & < "8.18~") | (= "dev")}
+  "coq" {(>= "8.11" & < "8.19~") | (= "dev")}
   "coq-bignums" 
 ]
 

--- a/meta.yml
+++ b/meta.yml
@@ -50,10 +50,11 @@ license:
 
 supported_coq_versions:
   text: Coq 8.11 or later (use releases for other Coq versions)
-  opam: '{(>= "8.11" & < "8.18~") | (= "dev")}'
+  opam: '{(>= "8.11" & < "8.19~") | (= "dev")}'
 
 tested_coq_opam_versions:
 - version: dev
+- version: "8.18"
 - version: "8.17"
 - version: "8.16"
 - version: "8.15"


### PR DESCRIPTION
In preparation for a new 8.18-compatible math-classes release.