### PR TITLE
Adapt to Coq PR #17832: syntax of choice in rewstrategy expects arguments at atomic level

### DIFF
--- a/theory/groups.v
+++ b/theory/groups.v
@@ -20,7 +20,7 @@ End semigroup_props.
 Ltac group_simplify :=
   rewrite_strat
     (try bottomup (hints group_simplify));
-    (try bottomup (choice (hints group_cancellation) <- associativity)).
+    (try bottomup (choice (hints group_cancellation) ( <- associativity ))).
 
 Ltac group := group_simplify; easy.
 


### PR DESCRIPTION
The PR is necessary to be compatible with the Coq PR coq/coq#17832 but if the patch is ok for you, this can be merged as soon as now.

PS: There are spaces in `( <- associativity )` to prevent the notation `(< x )` to be parsed instead.